### PR TITLE
Add basic SandSim implementation with React and Vite

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,22 @@
-# sandSim
+# SandSim
+
+This project is a minimal implementation of a falling-sand sandbox game built with React and Vite.
+
+## Development
+
+Install dependencies and run the development server:
+
+```bash
+npm install
+npm run dev
+```
+
+## Build
+
+To create a production build:
+
+```bash
+npm run build
+```
+
+Use `npm run preview` to serve the build locally.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>SandSim</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "sandsim",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "@types/react": "^18.0.0",
+    "@types/react-dom": "^18.0.0",
+    "@vitejs/plugin-react": "^4.0.0",
+    "typescript": "^5.0.0",
+    "vite": "^4.0.0"
+  }
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,0 +1,105 @@
+import { useEffect, useRef, useState } from 'react'
+import { GameState } from './types'
+import { WIDTH, HEIGHT, createInitialState, moveCluster, addPaletteColor } from './game'
+
+const CELL_SIZE = 20
+
+function useGame() {
+  const [state, setState] = useState<GameState>(() => createInitialState())
+
+  useEffect(() => {
+    const handleKey = (e: KeyboardEvent) => {
+      if (e.key === 'ArrowLeft') move(-1)
+      if (e.key === 'ArrowRight') move(1)
+    }
+    window.addEventListener('keydown', handleKey)
+    const interval = setInterval(() => move(0,1), 500)
+    return () => {
+      window.removeEventListener('keydown', handleKey)
+      clearInterval(interval)
+    }
+  }, [state])
+
+  function move(dx: number, dy: number = 0) {
+    setState(s => {
+      const copy: GameState = JSON.parse(JSON.stringify(s))
+      moveCluster(copy, dx, dy)
+      return copy
+    })
+  }
+
+  function addColor(color: string) {
+    setState(s => {
+      const copy: GameState = JSON.parse(JSON.stringify(s))
+      addPaletteColor(copy, color)
+      return copy
+    })
+  }
+
+  return { state, addColor }
+}
+
+export default function App() {
+  const canvasRef = useRef<HTMLCanvasElement>(null)
+  const { state, addColor } = useGame()
+
+  useEffect(() => {
+    const canvas = canvasRef.current!
+    canvas.width = WIDTH * CELL_SIZE
+    canvas.height = HEIGHT * CELL_SIZE
+    const ctx = canvas.getContext('2d')!
+
+    ctx.clearRect(0,0,canvas.width, canvas.height)
+    // draw board
+    for (let y = 0; y < HEIGHT; y++) {
+      for (let x = 0; x < WIDTH; x++) {
+        const c = state.board[y][x]
+        if (c) {
+          ctx.fillStyle = c
+          ctx.fillRect(x*CELL_SIZE, y*CELL_SIZE, CELL_SIZE, CELL_SIZE)
+        }
+      }
+    }
+    // draw active cluster
+    ctx.fillStyle = state.active.color
+    for (const [dx,dy] of state.active.shape) {
+      const x = state.active.x + dx
+      const y = state.active.y + dy
+      ctx.fillRect(x*CELL_SIZE, y*CELL_SIZE, CELL_SIZE, CELL_SIZE)
+    }
+  }, [state])
+
+  const previewStyle = { display:'flex', gap:'0.5rem', marginTop:'1rem' }
+
+  return (
+    <div>
+      <canvas ref={canvasRef} />
+      <div style={previewStyle}>
+        {state.queue.map((c, i) => (
+          <div key={i} style={{display:'grid',gridTemplateColumns:'repeat(4,10px)',gap:'1px'}}>
+            {Array.from({length:16}).map((_, idx) => {
+              const x = idx % 4
+              const y = Math.floor(idx / 4)
+              const filled = c.shape.some(([sx, sy]) => sx === x && sy === y)
+              return (
+                <div
+                  key={idx}
+                  style={{
+                    width: 10,
+                    height: 10,
+                    background: filled ? c.color : 'transparent',
+                    border: '1px solid #555',
+                  }}
+                />
+              )
+            })
+          </div>
+        ))
+      </div>
+      <div className="controls">
+        <input type="color" onChange={e=>addColor(e.target.value)} />
+      </div>
+    </div>
+  )
+}
+

--- a/src/game.ts
+++ b/src/game.ts
@@ -1,0 +1,142 @@
+import { Cell, Cluster, GameState } from './types'
+
+export const WIDTH = 10
+export const HEIGHT = 20
+
+export const DEFAULT_PALETTE = [
+  '#F94144',
+  '#F3722C',
+  '#90BE6D',
+  '#577590',
+  '#277DA1',
+]
+
+const SHAPES: [number, number][][] = [
+  [ [0,0], [1,0], [0,1], [1,1] ], // O
+  [ [0,0], [1,0], [2,0], [3,0] ], // I
+  [ [0,0], [1,0], [2,0], [2,1] ], // L
+  [ [0,0], [1,0], [2,0], [0,1] ], // J
+  [ [0,0], [1,0], [1,1], [2,1] ], // Z
+  [ [1,0], [2,0], [0,1], [1,1] ], // S
+]
+
+export function createEmptyBoard(): Cell[][] {
+  return Array.from({ length: HEIGHT }, () => Array<Cell>(WIDTH).fill(null))
+}
+
+function randomShape(): [number, number][] {
+  return SHAPES[Math.floor(Math.random() * SHAPES.length)]
+}
+
+function randomColor(palette: string[]): string {
+  return palette[Math.floor(Math.random() * palette.length)]
+}
+
+export function createCluster(palette: string[]): Cluster {
+  return {
+    shape: randomShape(),
+    color: randomColor(palette),
+    x: Math.floor(WIDTH / 2) - 1,
+    y: 0,
+  }
+}
+
+export function createInitialState(): GameState {
+  const palette = DEFAULT_PALETTE.slice()
+  const active = createCluster(palette)
+  const queue = [createCluster(palette), createCluster(palette)]
+  return { board: createEmptyBoard(), active, queue, palette }
+}
+
+export function mergeCluster(state: GameState) {
+  const { board, active } = state
+  for (const [dx, dy] of active.shape) {
+    const x = active.x + dx
+    const y = active.y + dy
+    if (y >= 0 && y < HEIGHT && x >= 0 && x < WIDTH) {
+      board[y][x] = active.color
+    }
+  }
+}
+
+export function canMove(cluster: Cluster, board: Cell[][], dx: number, dy: number): boolean {
+  for (const [sx, sy] of cluster.shape) {
+    const x = cluster.x + sx + dx
+    const y = cluster.y + sy + dy
+    if (x < 0 || x >= WIDTH || y >= HEIGHT) return false
+    if (y >= 0 && board[y][x]) return false
+  }
+  return true
+}
+
+export function moveCluster(state: GameState, dx: number, dy: number) {
+  if (canMove(state.active, state.board, dx, dy)) {
+    state.active.x += dx
+    state.active.y += dy
+  } else if (dy === 1) {
+    // landed
+    mergeCluster(state)
+    clearLines(state.board)
+    settle(state.board)
+    state.active = state.queue.shift()!
+    state.queue.push(createCluster(state.palette))
+  }
+}
+
+export function settle(board: Cell[][]) {
+  let moved = false
+  do {
+    moved = false
+    for (let y = HEIGHT - 2; y >= 0; y--) {
+      for (let x = 0; x < WIDTH; x++) {
+        if (board[y][x] && !board[y+1][x]) {
+          board[y+1][x] = board[y][x]
+          board[y][x] = null
+          moved = true
+        }
+      }
+    }
+  } while (moved)
+}
+
+export function clearLines(board: Cell[][]) {
+  for (let y = 0; y < HEIGHT; y++) {
+    const color = board[y][0]
+    if (!color) continue
+    let full = true
+    for (let x = 1; x < WIDTH; x++) {
+      if (board[y][x] !== color) {
+        full = false
+        break
+      }
+    }
+    if (full) {
+      bfsClear(board, y, color)
+    }
+  }
+}
+
+function bfsClear(board: Cell[][], y: number, color: string) {
+  const queue: [number, number][] = []
+  const visited = new Set<string>()
+  for (let x = 0; x < WIDTH; x++) {
+    queue.push([x, y])
+  }
+  while (queue.length) {
+    const [cx, cy] = queue.shift()!
+    if (cx < 0 || cx >= WIDTH || cy < 0 || cy >= HEIGHT) continue
+    const key = `${cx},${cy}`
+    if (visited.has(key)) continue
+    if (board[cy][cx] !== color) continue
+    visited.add(key)
+    board[cy][cx] = null
+    queue.push([cx+1, cy])
+    queue.push([cx-1, cy])
+    queue.push([cx, cy+1])
+    queue.push([cx, cy-1])
+  }
+}
+
+export function addPaletteColor(state: GameState, color: string) {
+  state.palette.push(color)
+}

--- a/src/index.css
+++ b/src/index.css
@@ -1,0 +1,34 @@
+body {
+  margin: 0;
+  font-family: sans-serif;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  height: 100vh;
+  background: #222;
+  color: white;
+}
+
+canvas {
+  background: #111;
+  border: 1px solid #555;
+}
+
+.controls {
+  margin-top: 1rem;
+  display: flex;
+  gap: 0.5rem;
+  justify-content: center;
+}
+
+.palette {
+  display: flex;
+  gap: 0.25rem;
+}
+
+.palette button {
+  width: 20px;
+  height: 20px;
+  border: none;
+  cursor: pointer;
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,0 +1,10 @@
+import React from 'react'
+import ReactDOM from 'react-dom/client'
+import App from './App'
+import './index.css'
+
+ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+)

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,15 @@
+export type Cell = string | null
+
+export interface Cluster {
+  shape: [number, number][]
+  color: string
+  x: number
+  y: number
+}
+
+export interface GameState {
+  board: Cell[][]
+  active: Cluster
+  queue: Cluster[]
+  palette: string[]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "useDefineForClassFields": true,
+    "lib": ["DOM", "DOM.Iterable", "ESNext"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "esModuleInterop": false,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx"
+  },
+  "include": ["src"],
+  "references": [{ "path": "./tsconfig.node.json" }]
+}

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "allowSyntheticDefaultImports": true
+  },
+  "include": ["vite.config.ts"]
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,0 +1,6 @@
+import { defineConfig } from 'vite'
+import react from '@vitejs/plugin-react'
+
+export default defineConfig({
+  plugins: [react()],
+})


### PR DESCRIPTION
## Summary
- scaffold Vite + React project
- implement falling sand clusters with simple physics
- allow palette customization and show preview queue
- document development workflow

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6859613233f48333a2fd775f6cc32990