### PR TITLE
Add fine-grained sand physics

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,8 +1,8 @@
 import { useEffect, useRef, useState } from 'react'
 import { GameState } from './types'
-import { WIDTH, HEIGHT, createInitialState, moveCluster, addPaletteColor } from './game'
+import { WIDTH, HEIGHT, PIXEL_WIDTH, PIXEL_HEIGHT, SUBDIV, createInitialState, moveCluster, addPaletteColor } from './game'
 
-const CELL_SIZE = 20
+const CELL_SIZE = 1
 
 function useGame() {
   const [state, setState] = useState<GameState>(() => createInitialState())
@@ -45,14 +45,14 @@ export default function App() {
 
   useEffect(() => {
     const canvas = canvasRef.current!
-    canvas.width = WIDTH * CELL_SIZE
-    canvas.height = HEIGHT * CELL_SIZE
+    canvas.width = PIXEL_WIDTH * CELL_SIZE
+    canvas.height = PIXEL_HEIGHT * CELL_SIZE
     const ctx = canvas.getContext('2d')!
 
     ctx.clearRect(0,0,canvas.width, canvas.height)
     // draw board
-    for (let y = 0; y < HEIGHT; y++) {
-      for (let x = 0; x < WIDTH; x++) {
+    for (let y = 0; y < PIXEL_HEIGHT; y++) {
+      for (let x = 0; x < PIXEL_WIDTH; x++) {
         const c = state.board[y][x]
         if (c) {
           ctx.fillStyle = c
@@ -63,9 +63,9 @@ export default function App() {
     // draw active cluster
     ctx.fillStyle = state.active.color
     for (const [dx,dy] of state.active.shape) {
-      const x = state.active.x + dx
-      const y = state.active.y + dy
-      ctx.fillRect(x*CELL_SIZE, y*CELL_SIZE, CELL_SIZE, CELL_SIZE)
+      const x = (state.active.x + dx) * SUBDIV
+      const y = (state.active.y + dy) * SUBDIV
+      ctx.fillRect(x*CELL_SIZE, y*CELL_SIZE, SUBDIV*CELL_SIZE, SUBDIV*CELL_SIZE)
     }
   }, [state])
 

--- a/src/game.ts
+++ b/src/game.ts
@@ -1,7 +1,41 @@
-import { Cell, Cluster, GameState } from './types'
+import { Pixel, Cluster, GameState } from './types'
 
 export const WIDTH = 10
 export const HEIGHT = 20
+
+/**
+ * Number of sand pixels that make up one traditional Tetris block. A higher
+ * value means finer grained sand simulation.
+ */
+export const SUBDIV = 150
+
+export const PIXEL_WIDTH = WIDTH * SUBDIV
+export const PIXEL_HEIGHT = HEIGHT * SUBDIV
+
+function regionOccupied(board: Pixel[][], cellX: number, cellY: number): boolean {
+  const sx = cellX * SUBDIV
+  const sy = cellY * SUBDIV
+  for (let y = 0; y < SUBDIV; y++) {
+    for (let x = 0; x < SUBDIV; x++) {
+      if (board[sy + y] && board[sy + y][sx + x]) return true
+    }
+  }
+  return false
+}
+
+function fillRegion(board: Pixel[][], cellX: number, cellY: number, color: string) {
+  const sx = cellX * SUBDIV
+  const sy = cellY * SUBDIV
+  for (let y = 0; y < SUBDIV; y++) {
+    for (let x = 0; x < SUBDIV; x++) {
+      const py = sy + y
+      const px = sx + x
+      if (py >= 0 && py < PIXEL_HEIGHT && px >= 0 && px < PIXEL_WIDTH) {
+        board[py][px] = color
+      }
+    }
+  }
+}
 
 export const DEFAULT_PALETTE = [
   '#F94144',
@@ -20,8 +54,10 @@ const SHAPES: [number, number][][] = [
   [ [1,0], [2,0], [0,1], [1,1] ], // S
 ]
 
-export function createEmptyBoard(): Cell[][] {
-  return Array.from({ length: HEIGHT }, () => Array<Cell>(WIDTH).fill(null))
+export function createEmptyBoard(): Pixel[][] {
+  return Array.from({ length: PIXEL_HEIGHT }, () =>
+    Array<Pixel>(PIXEL_WIDTH).fill(null)
+  )
 }
 
 function randomShape(): [number, number][] {
@@ -54,17 +90,17 @@ export function mergeCluster(state: GameState) {
     const x = active.x + dx
     const y = active.y + dy
     if (y >= 0 && y < HEIGHT && x >= 0 && x < WIDTH) {
-      board[y][x] = active.color
+      fillRegion(board, x, y, active.color)
     }
   }
 }
 
-export function canMove(cluster: Cluster, board: Cell[][], dx: number, dy: number): boolean {
+export function canMove(cluster: Cluster, board: Pixel[][], dx: number, dy: number): boolean {
   for (const [sx, sy] of cluster.shape) {
     const x = cluster.x + sx + dx
     const y = cluster.y + sy + dy
     if (x < 0 || x >= WIDTH || y >= HEIGHT) return false
-    if (y >= 0 && board[y][x]) return false
+    if (y >= 0 && regionOccupied(board, x, y)) return false
   }
   return true
 }
@@ -83,28 +119,50 @@ export function moveCluster(state: GameState, dx: number, dy: number) {
   }
 }
 
-export function settle(board: Cell[][]) {
+export function settle(board: Pixel[][]) {
   let moved = false
   do {
     moved = false
-    for (let y = HEIGHT - 2; y >= 0; y--) {
-      for (let x = 0; x < WIDTH; x++) {
-        if (board[y][x] && !board[y+1][x]) {
-          board[y+1][x] = board[y][x]
+    for (let y = PIXEL_HEIGHT - 2; y >= 0; y--) {
+      for (let x = 0; x < PIXEL_WIDTH; x++) {
+        const c = board[y][x]
+        if (!c) continue
+        if (!board[y+1][x]) {
+          board[y+1][x] = c
           board[y][x] = null
           moved = true
+        } else {
+          const left = x > 0 && !board[y+1][x-1]
+          const right = x < PIXEL_WIDTH - 1 && !board[y+1][x+1]
+          if (left && right) {
+            if (Math.random() < 0.5) {
+              board[y+1][x-1] = c
+            } else {
+              board[y+1][x+1] = c
+            }
+            board[y][x] = null
+            moved = true
+          } else if (left) {
+            board[y+1][x-1] = c
+            board[y][x] = null
+            moved = true
+          } else if (right) {
+            board[y+1][x+1] = c
+            board[y][x] = null
+            moved = true
+          }
         }
       }
     }
   } while (moved)
 }
 
-export function clearLines(board: Cell[][]) {
-  for (let y = 0; y < HEIGHT; y++) {
+export function clearLines(board: Pixel[][]) {
+  for (let y = 0; y < PIXEL_HEIGHT; y++) {
     const color = board[y][0]
     if (!color) continue
     let full = true
-    for (let x = 1; x < WIDTH; x++) {
+    for (let x = 1; x < PIXEL_WIDTH; x++) {
       if (board[y][x] !== color) {
         full = false
         break
@@ -116,15 +174,15 @@ export function clearLines(board: Cell[][]) {
   }
 }
 
-function bfsClear(board: Cell[][], y: number, color: string) {
+function bfsClear(board: Pixel[][], y: number, color: string) {
   const queue: [number, number][] = []
   const visited = new Set<string>()
-  for (let x = 0; x < WIDTH; x++) {
+  for (let x = 0; x < PIXEL_WIDTH; x++) {
     queue.push([x, y])
   }
   while (queue.length) {
     const [cx, cy] = queue.shift()!
-    if (cx < 0 || cx >= WIDTH || cy < 0 || cy >= HEIGHT) continue
+    if (cx < 0 || cx >= PIXEL_WIDTH || cy < 0 || cy >= PIXEL_HEIGHT) continue
     const key = `${cx},${cy}`
     if (visited.has(key)) continue
     if (board[cy][cx] !== color) continue

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,11 @@
 export type Cell = string | null
 
+/**
+ * A single sand pixel. When null, the pixel is empty. Otherwise it contains the
+ * color of the sand grain occupying that location.
+ */
+export type Pixel = string | null
+
 export interface Cluster {
   shape: [number, number][]
   color: string
@@ -8,7 +14,11 @@ export interface Cluster {
 }
 
 export interface GameState {
-  board: Cell[][]
+  /**
+   * 2D array representing the sand field at pixel resolution. The dimensions
+   * are determined by the constants in `game.ts`.
+   */
+  board: Pixel[][]
   active: Cluster
   queue: Cluster[]
   palette: string[]


### PR DESCRIPTION
## Summary
- simulate sand at pixel resolution by introducing `SUBDIV`
- render board and active pieces with many sub-pixels
- update physics routines to operate on a `Pixel[][]` board

## Testing
- `npm run build` *(fails: vite not found)*
- `npx tsc --noEmit` *(fails: cannot find module 'react')*

------
https://chatgpt.com/codex/tasks/task_e_68598976390c8333bc80c171cb66280a